### PR TITLE
fix: learn menu link lv2 bug

### DIFF
--- a/src/components/LearnMenu/index.tsx
+++ b/src/components/LearnMenu/index.tsx
@@ -52,7 +52,7 @@ const LearnMenu: FunctionComponent<{
 										key={lv2Index}
 										className="learn-menu__link-lv2"
 										onClick={() => {
-											handleLinkClick(`#learn_${lv0Index}_${lv1Index}_${lv2Index}`)
+											handleLinkClick(`learn_${lv0Index}_${lv1Index}_${lv2Index}`)
 										}}
 									>
 										{lv2Entry.title}


### PR DESCRIPTION
## Description

When lv2 list element is clicked, the page does not scroll to view for selected heading

## Screenshot

![Screen Shot 2021-10-05 at 1 50 04 PM](https://user-images.githubusercontent.com/46070006/136017404-a3f1ed06-ce26-45f9-b444-a9fc521305f5.png)
